### PR TITLE
'unranked' when player doesnt have rank in region/country

### DIFF
--- a/src/app/components/player-profile/overall-stats/position/position.component.html
+++ b/src/app/components/player-profile/overall-stats/position/position.component.html
@@ -1,11 +1,11 @@
 <div *ngIf="loaded" class="flags">
     <div class="section-flag" matTooltip="Position in country" [matTooltipPosition]="'above'">
       <app-flag [country]="country" [size]="32"></app-flag>
-    <span class="position-value"><span> {{country | uppercase}}: &nbsp;</span>{{positionInCountry | number: '1.'}}</span>
+    <span class="position-value"><span> {{country | uppercase}}: &nbsp;</span>{{formatPlayerRankingPosition(positionInCountry)}}</span>
   </div>
   <div class="section-flag" matTooltip="Position in region" [matTooltipPosition]="'above'">
    <app-flag [country]="region" [size]="32"></app-flag>
-    <span class="position-value"><span> {{region | uppercase}}: &nbsp;</span>{{positionInRegion | number: '1.'}}</span>
+    <span class="position-value"><span> {{region | uppercase}}: &nbsp;</span>{{formatPlayerRankingPosition(positionInRegion)}}</span>
   </div>
 </div>
 

--- a/src/app/components/player-profile/overall-stats/position/position.component.ts
+++ b/src/app/components/player-profile/overall-stats/position/position.component.ts
@@ -28,4 +28,8 @@ export class PositionComponent implements OnInit {
       }
     );
   }
+
+  public formatPlayerRankingPosition(position: number) {
+    return position === 0 ? 'unranked' : position;
+  }
 }


### PR DESCRIPTION
I've removed pipe `number: '1.'`, because its integer in API reponse:
```
data class PlayerPositionResponse(val playerId: String,
                                  val positionInRegion: Int,
                                  val positionInCountry: Int)

```
![image](https://user-images.githubusercontent.com/17440354/96146807-fdf75f80-0f06-11eb-988e-1b568179427e.png)
![image](https://user-images.githubusercontent.com/17440354/96146831-02237d00-0f07-11eb-9295-4f33313561e4.png)
